### PR TITLE
Minor update in git and conda dependencies

### DIFF
--- a/environment.yaml
+++ b/environment.yaml
@@ -4,6 +4,7 @@ channels:
 - robostack-staging
 dependencies:
 - boost[version='>=1.82']
+- pinocchio
 - bullet
 - ccache
 - cmake

--- a/git-deps.yaml
+++ b/git-deps.yaml
@@ -3,6 +3,10 @@ repositories:
     type: git
     url: https://github.com/eclipse-cyclonedds/cyclonedds
     version: releases/0.10.x
+  go2_description:
+    type: git
+    url: git@github.com:inria-paris-robotics-lab/go2_description.git
+    version: master
   go2_simulation:
     type: git
     url: git@github.com:inria-paris-robotics-lab/go2_simulation.git


### PR DESCRIPTION
I added Pinocchio in the conda dependencies and **go2_description** in the git dependencies.

It is not strictly needed for this project. But since this project also come by default go2_simulation and pybullet, I added those two dependencies so that go2_simulation with pybullet works out of the box.