### PR TITLE
Compute ddq

### DIFF
--- a/go2_control_interface_cpp/include/go2_control_interface_cpp/robot_interface.hpp
+++ b/go2_control_interface_cpp/include/go2_control_interface_cpp/robot_interface.hpp
@@ -5,7 +5,6 @@
 #include "unitree_go/msg/low_cmd.hpp"
 #include "unitree_go/msg/low_state.hpp"
 #include <Eigen/Dense>
-#include <chrono>
 
 /**
  * Maps the indices of elements in the source array to their corresponding
@@ -207,6 +206,7 @@ private:
 
   // Parameter to filter the velocity (as it is quite noisy on the real go2 robot)
   double filter_fq_; ///< Cut-off frequency of the filter
+  double robot_fq_; ///< Robot frequency at which state is published (500Hz for the Go2)
 
   // Messages
   unitree_go::msg::LowCmd cmd_; ///< Pointer to a pre-filled LowCmd message

--- a/go2_control_interface_cpp/src/robot_interface.cpp
+++ b/go2_control_interface_cpp/src/robot_interface.cpp
@@ -5,7 +5,6 @@
 #include "std_msgs/msg/bool.hpp"
 #include "unitree_go/msg/low_cmd.hpp"
 #include "unitree_go/msg/low_state.hpp"
-#include <cstddef>
 
 Go2RobotInterface::Go2RobotInterface(rclcpp::Node & node, const std::array<std::string_view, 12> source_joint_order)
 : node_(node)
@@ -26,7 +25,8 @@ Go2RobotInterface::Go2RobotInterface(rclcpp::Node & node, const std::array<std::
   scaling_gain_ = node.declare_parameter("scaling_gain", 1.0);
   scaling_ff_ = node.declare_parameter("scaling_ff", 1.0);
 
-  filter_fq_ = node.declare_parameter("joint_filter_fq", -1.0); // By default no filter
+  filter_fq_ = node.declare_parameter("joints_filter_fq", -1.0); // By default no filter
+  robot_fq_ = node.declare_parameter("robot_fq", 500.); // For the current Go2 robot
 
   // Subscribe to the /lowstate and /watchdog/is_safe topics
   state_subscription_ = node_.create_subscription<unitree_go::msg::LowState>(
@@ -229,10 +229,12 @@ void Go2RobotInterface::consume_state(const unitree_go::msg::LowState::SharedPtr
   }
   else
   {
-    const double b = 1. / (1 + 2 * 3.14 * (t - this->state_t_).seconds() * this->filter_fq_);
-    state_q_ = (1 - b) * q_meas + b * state_q_;
-    state_dq_ = (1 - b) * dq_meas + b * state_dq_;
-    state_ddq_ = (1 - b) * ddq_meas + b * state_ddq_;
+    // Filtered derivative (https://fr.mathworks.com/help/sps/ref/filteredderivativediscreteorcontinuous.html#d126e104759)
+    state_ddq_ = this->filter_fq_ * (dq_meas - state_dq_); // Do that operation first to have the previous dq
+
+    const double  a = this->filter_fq_ / this->robot_fq_;
+    state_dq_ = (1-a) * state_dq_ + a * dq_meas;
+    state_q_ = (1-a) * state_q_ + a * q_meas;
   }
 
   this->state_t_ = t;

--- a/go2_control_interface_cpp/src/robot_interface.cpp
+++ b/go2_control_interface_cpp/src/robot_interface.cpp
@@ -223,9 +223,10 @@ void Go2RobotInterface::consume_state(const unitree_go::msg::LowState::SharedPtr
   if (this->state_t_.nanoseconds() == 0 || this->filter_fq_ <= 0.)
   {
     // No filtering to do on first point
-    state_q_ = q_meas;
+    state_ddq_ = this->robot_fq_ * (dq_meas - state_dq_); // Do that operation first to have the previous dq
+
     state_dq_ = dq_meas;
-    state_ddq_ = ddq_meas;
+    state_q_ = q_meas;
   }
   else
   {

--- a/go2_control_interface_py/robot_interface.py
+++ b/go2_control_interface_py/robot_interface.py
@@ -38,6 +38,10 @@ class Go2RobotInterface():
         self.filter_fq = self.node.declare_parameter("joints_filter_fq", -1.0, ParameterDescriptor(description="Characteristic frequency of the filters on q, dq, ddq")).value # By default no filter
         self.robot_fq = self.node.declare_parameter("robot_fq", 500., ParameterDescriptor(description="Frequency at which the robot state messages are published")).value # 500Hz for the Go2
 
+        if self.filter_fq > self.robot_fq:
+            node.get_logger().warn("Joint filter freq higher than robot sampling freq. Disabling filter. %f > %f" % (self.filter_fq, self.robot_fq))
+            self.filter_fq = -1.0
+
         self.crc = CRC()
         self.user_cb = None
         # TODO: Add a callback to joint_states and verify that robots is within safety bounds

--- a/go2_control_interface_py/robot_interface.py
+++ b/go2_control_interface_py/robot_interface.py
@@ -141,10 +141,12 @@ class Go2RobotInterface():
         last_tqva = self.last_state_tqva
         if last_tqva is None or self.filter_fq <= 0.:
             # No filtering to do on first point
-            self.last_state_tqva = t, q_urdf, v_urdf, a_urdf
+            v_prev = last_tqva[2] if last_tqva is not None else [0.]*12
+            a_finite_diff = [self.robot_fq * (v_urdf[i] - v_prev[i]) for i in range(12)] # Do that operation first to have the previous v
+
+            self.last_state_tqva = t, q_urdf, v_urdf, a_finite_diff
         else:
             t_prev, q_prev, v_prev, a_prev = last_tqva
-
             # Filtered derivative (https://fr.mathworks.com/help/sps/ref/filteredderivativediscreteorcontinuous.html#d126e104759)
             a_filter = [self.filter_fq_ * (v_urdf[i] - v_prev[i]) for i in range(12)] # Do that operation first to have the previous v
 


### PR DESCRIPTION
Following this issue https://github.com/inria-paris-robotics-lab/go2_control_interface/issues/12

The filter has been modified to perform a "Filtered derivative" in one go on dq and get ddq at the same time. See https://fr.mathworks.com/help/sps/ref/filteredderivativediscreteorcontinuous.html#d126e104759

Note, the filter frequency has now changed meaning ! For instance, previously filter freq of 15hz now correspond to a freq of 80Hz ! (which makes a lot more physical sense...)

To be sure that there are no confusions, the parameter has been renamed from **joint_filter_fq** to **joints_filter_fq**
(better have no filter, that a filter that takes everything out 15 << 80Hz)