### PR TITLE
Port RobotControlInterface filter minor changes to python

### DIFF
--- a/go2_control_interface_common/watchdog_node.py
+++ b/go2_control_interface_common/watchdog_node.py
@@ -28,7 +28,7 @@ class WatchDogNode(Node, Go2RobotInterface):
     """
     def __init__(self):
         Node.__init__(self, "watchdog")
-        Go2RobotInterface.__init__(self, self)
+        Go2RobotInterface.__init__(self, self, joints_filter_fq_default = 200)
 
         # Watchdog timer parameters
         self.freq = self.declare_parameter("freq", 100).value
@@ -42,9 +42,6 @@ class WatchDogNode(Node, Go2RobotInterface):
         assert len(self.q_min) == 12, "Parameter q_min should be length 12"
         assert len(self.margin_duration) == 12, "Parameter margin_duration should be length 12"
         assert all(d >= 0. for d in self.margin_duration), "Parameter margin_duration should be non negative"
-
-        # Use RobotInterface variable to filter dq
-        self.filter_fq = 200
 
         # Watchdog timer logic
         self.cnt = 0

--- a/go2_control_interface_py/robot_interface.py
+++ b/go2_control_interface_py/robot_interface.py
@@ -39,8 +39,13 @@ class Go2RobotInterface():
         self.robot_fq = self.node.declare_parameter("robot_fq", 500., ParameterDescriptor(description="Frequency at which the robot state messages are published")).value # 500Hz for the Go2
 
         if self.filter_fq > self.robot_fq:
-            node.get_logger().warn("Joint filter freq higher than robot sampling freq. Disabling filter. %f > %f" % (self.filter_fq, self.robot_fq))
-            self.filter_fq = -1.0
+            node.get_logger().error("Go2RobotInterface: Joint filter freq higher than robot sampling freq, stopping node ! %f > %f" % (self.filter_fq, self.robot_fq))
+            assert False, "Go2RobotInterface: Joint filter freq higher than robot sampling freq, stopping node !"
+
+        if self.filter_fq > 0:
+            node.get_logger().info("Go2RobotInterface: Joint filter frequency set to %f Hz." % self.filter_fq);
+        else:
+            node.get_logger().info("Go2RobotInterface: Joint filtering disabled.");
 
         self.crc = CRC()
         self.user_cb = None
@@ -59,16 +64,16 @@ class Go2RobotInterface():
         arm_watchdog_msg.data = True
         self._watchdog_publisher.publish(arm_watchdog_msg)
 
-        self.node.get_logger().info("Waiting for watchdog to be armed...")
+        self.node.get_logger().info("Go2RobotInterface: Waiting for watchdog to be armed...")
         while(not self.is_safe and rclpy.ok()):
             self.node.get_clock().sleep_for(Duration(seconds=.1))
 
         if(goto_config):
-            self.node.get_logger().info("Going to start configuration...")
+            self.node.get_logger().info("Go2RobotInterface: Going to start configuration...")
             self._go_to_configuration__(q_start, 5.0)
-            self.node.get_logger().info("Start configuration reached.")
+            self.node.get_logger().info("Go2RobotInterface: Start configuration reached.")
         else:
-            self.node.get_logger().info("Skipping start configuration, set command to zero")
+            self.node.get_logger().info("Go2RobotInterface: Skipping start configuration, set command to zero")
             zeros = [0.] * 12
             self._send_command(zeros, zeros, zeros, zeros, zeros, 0.0)
         self.is_ready = True

--- a/go2_control_interface_py/robot_interface.py
+++ b/go2_control_interface_py/robot_interface.py
@@ -18,7 +18,7 @@ class Go2RobotInterface():
             6,  7,  8,
         ] # re-ordering joints
 
-    def __init__(self, node: Node):
+    def __init__(self, node: Node, *, joints_filter_fq_default=-1.0):
         self.is_ready = False
         self.is_safe = False
 
@@ -35,7 +35,7 @@ class Go2RobotInterface():
         self.scaling_ff = self.node.declare_parameter("scaling_ff", 1.0).value
 
         self.last_state_tqva = None
-        self.filter_fq = self.node.declare_parameter("joints_filter_fq", -1.0, ParameterDescriptor(description="Characteristic frequency of the filters on q, dq, ddq")).value # By default no filter
+        self.filter_fq = self.node.declare_parameter("joints_filter_fq", joints_filter_fq_default, ParameterDescriptor(description="Characteristic frequency of the filters on q, dq, ddq")).value # By default no filter
         self.robot_fq = self.node.declare_parameter("robot_fq", 500., ParameterDescriptor(description="Frequency at which the robot state messages are published")).value # 500Hz for the Go2
 
         if self.filter_fq > self.robot_fq:


### PR DESCRIPTION
Now the python RobotControlInterface also prints the joint filter frequency (for debug purpose) and also trigger an assert if the filter freq is higher than robot freq.

Also an keyword only argument has been added in the constructor for the watchdog to "cleanly" set the filter frq