### PR TITLE
Fixi pipeline for mac arm architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ source install/setup.bash
 * C. Build all remaining packages
 
 ```bash
-colcon build --packages-skip unitree_sdk2_python
+colcon build --packages-skip unitree_sdk2py
 ```
 
 6. Source the environment

--- a/environment.yaml
+++ b/environment.yaml
@@ -3,7 +3,6 @@ channels:
 - conda-forge
 - robostack-staging
 dependencies:
-- boost[version='>=1.82']
 - pinocchio
 - bullet
 - ccache

--- a/go2_control_interface_common/watchdog_node.py
+++ b/go2_control_interface_common/watchdog_node.py
@@ -1,4 +1,4 @@
-#!/bin/env python3
+#!/usr/bin/env python3
 
 import rclpy
 from rclpy.node import Node


### PR DESCRIPTION
this allows to create the necessary conda env now on mac arm, thanks to solving #3. 